### PR TITLE
Tilføj debounce til search-feltet

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,13 @@
     <meta charset="utf-8" />
     <link type="text/css" href="spotifyvue.css" rel="stylesheet">
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
+
+    <script src="https://unpkg.com/vue/dist/vue.js"></script>
+    <script src="https://unpkg.com/vue-resource@1.2.0/dist/vue-resource.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.4/lodash.min.js"></script>
+
+    <script src="https://cdn.rawgit.com/Reactive-Extensions/RxJS/master/dist/rx.lite.js"></script>
+    <script src="https://cdn.rawgit.com/vuejs/vue-rx/aba16a21/vue-rx.js"></script>
 </head>
 
 <body>
@@ -31,9 +38,6 @@
 
         <div id="overlay" v-if="loading || modalOverlay" v-on:click="closeModal"></div>
     </div>
-    <script src="https://unpkg.com/vue/dist/vue.js"></script>
-    <script src="https://unpkg.com/vue-resource@1.2.0/dist/vue-resource.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.4/lodash.min.js"></script>
     <script src="js/app.js"></script>
 </body>
 

--- a/js/app.js
+++ b/js/app.js
@@ -30,7 +30,7 @@ Vue.component('search-box', {
             inputValue: this.$fromDOMEvent('#query', 'keyup').pluck('target', 'value')
                 .debounce(300)                                          // Vent til der ikke er tastet i 300ms
                 .distinctUntilChanged()                                 // Fyr kun hvis værdien har ændret sig
-                .filter(query => query)                                 // Filtrer tomme værdier fra.
+                .filter(query => query.length > 0)                      // Filtrer tomme værdier fra.
                 .startWith('love')                                      // Start med søgningen 'love'
                 .do(query => this.getSearchResult('search', query))     // Fyr søgningen.
         }

--- a/js/app.js
+++ b/js/app.js
@@ -21,14 +21,9 @@ Vue.component('search-box', {
     props: ['getSearchResult'],
     template: `
     <div id="searchBox">
-        <input id="query" type="text" autofocus>
+        <input id="query" type="text" value="love" autofocus>
         <button id="searchButton" v-on:click="getSearchResult('search', searchquery)">Search</button>
     </div>`,
-    created: function() {
-        //this.searchquery = window.sessionStorage.lastQuery;
-        this.searchquery = 'love';
-        this.getSearchResult('search', this.searchquery); // Search on reload
-    },
     subscriptions () {
         return {
             // Dette er en observable som fyrer på keyup fra #query-elementet.
@@ -36,6 +31,7 @@ Vue.component('search-box', {
                 .debounce(300)                                          // Vent til der ikke er tastet i 300ms
                 .distinctUntilChanged()                                 // Fyr kun hvis værdien har ændret sig
                 .filter(query => query)                                 // Filtrer tomme værdier fra.
+                .startWith('love')                                      // Start med søgningen 'love'
                 .do(query => this.getSearchResult('search', query))     // Fyr søgningen.
         }
     }


### PR DESCRIPTION
Hej Niels.

Jeg fik lyst til at se hvordan RxJS (mit favoritplugin) kører med Vue. Jeg har brugt det til at lave en debounce-funktion på sit søgefelt. Koden har jeg mere eller mindre kopieret fra Idrætsmusik.dks spotify-søgefelt.

Måske kan arkitekturen laves endnu bedre, men her er altså første forsøg.

Bemærk søgningen 'love' fyres fra startWith('love') - men også er sat som value på inputtet. Det er selvfølgelig ikke optimalt, men skal den overhovedet starte med en søgning?

Bemærk desuden jeg har flyttet alle scripts undtagen app.js til HEAD i html'en.

Vi ses.